### PR TITLE
Make compatible with PlatformIO

### DIFF
--- a/src/SafeString.h
+++ b/src/SafeString.h
@@ -304,7 +304,7 @@ SafeString_ConstructorAndDebugging.ino, SafeStringFromCharArray.ino, SafeStringF
 
   
 ****************************************************************************************/
-class SafeString : public Printable, public Print {
+class SafeString : public arduino::Printable, public Print {
 
   public:
 /*********************************************


### PR DESCRIPTION
I found I couldn't build projects using this library with PlatformIO because you use Printable without prefixing the Arduino namespace to it. Simply adding this fixes it, and everything still builds successfully with the Arduino IDE.